### PR TITLE
Weak Announcement Support

### DIFF
--- a/rowan/components/gemstone/Announcements.ston
+++ b/rowan/components/gemstone/Announcements.ston
@@ -3,8 +3,6 @@ RwPlatformNestedProjectLoadComponentV2 {
 	#condition : [
 		'gs3.[7-]'
 	],
-	#projectNames : [ ],
-	#componentNames : [ ],
 	#packageNames : [
 		'Announcements-Core-GemStone',
 		'Announcements-Extensions-GemStone'

--- a/rowan/components/tests/gemstone/Announcements.ston
+++ b/rowan/components/tests/gemstone/Announcements.ston
@@ -3,8 +3,6 @@ RwPlatformNestedProjectLoadComponentV2 {
 	#condition : [
 		'gs3.[7-]'
 	],
-	#projectNames : [ ],
-	#componentNames : [ ],
 	#packageNames : [
 		'Announcements-Core-GemStone-Test'
 	],

--- a/src/Announcements-Core-GemStone-Test/WeakAnnouncerTest.class.st
+++ b/src/Announcements-Core-GemStone-Test/WeakAnnouncerTest.class.st
@@ -1,0 +1,144 @@
+"
+SUnit tests for weak announcements
+"
+Class {
+	#name : 'WeakAnnouncerTest',
+	#superclass : 'AnnouncerTest',
+	#category : 'Announcements-Core-GemStone-Test'
+}
+
+{ #category : 'asserting' }
+WeakAnnouncerTest >> assert: anObject
+identicalTo: bObject [
+
+	^self assert: anObject == bObject
+]
+
+{ #category : 'utilities' }
+WeakAnnouncerTest >> maximumReclamation [
+
+	System _generationScavenge_vmMarkSweep.
+	System _generationScavenge_vmMarkSweep.
+	(Delay forMilliseconds: 10) wait.
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testMakeStrong [
+
+	| counter collector forwarder subscription |
+	counter := 0.
+	collector := [ counter := counter + 1 ].
+	forwarder := MessageSend receiver: collector selector: #value.
+	subscription := announcer weak when: AnnouncementMockA send: #value to: forwarder.
+	
+	" shouldn't go away, we are still holding a reference to 'forwarder': "
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1.
+	
+	"Shouldn't go away since we converted to a strong sub"
+	subscription := subscription makeStrong.
+	forwarder := nil.
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 2
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testNoDeadWeakSubscriptions [
+
+	self maximumReclamation.
+	self assert: (WeakAnnouncementSubscription allInstancesInMemory select: [ :sub | sub subscriber isNil ]) isEmpty.
+	self assert: (WeakAnnouncementSubscription allInstancesInMemory select: [ :sub | sub subscriber isNil ]) isEmpty
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testWeakBlockUnsupported [
+	"We support weak blocks though they aren't all that useful."
+
+	| counter |
+	counter := 0.
+	self
+		should: [announcer weak when: AnnouncementMockA send: #value to: []]
+		raise: WeakBlockUnsupported.
+	self
+		should: [(announcer when: AnnouncementMockA do: [ :ann | counter := counter + 1 ] for: self) makeWeak]
+		raise: WeakBlockUnsupported
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testWeakDoubleAnnouncer [
+
+	| a1 a2 o |
+	a1 := Announcer new.
+	a2 := Announcer new.
+	o := Object new.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 0.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 0.
+	
+	a1 weak
+		when: Announcement
+		send: #abcdef
+		to: o.
+	a2 weak
+		when: Announcement
+		send: #abcdef
+		to: o.	
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 1.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 1.
+	
+	self maximumReclamation.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 1.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 1.	
+
+	o := nil.
+	self maximumReclamation.
+	self 
+		assert: a1 subscriptions numberOfSubscriptions
+		equals: 0.
+	self
+		assert: a2 subscriptions numberOfSubscriptions
+		equals: 0.
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testWeakObject [
+
+	| counter collector forwarder |
+	counter := 0.
+	collector := [ counter := counter + 1 ].
+	forwarder := MessageSend receiver: collector selector: #value.
+	(announcer when: AnnouncementMockA send: #value to: forwarder) makeWeak.
+	
+	" shouldn't go away, we are still holding a reference to 'forwarder': "
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1.
+	
+	" should go away as we let the only reference to 'forwarder' go: "
+	forwarder := nil.
+	self maximumReclamation.
+	announcer announce: AnnouncementMockA.
+	self assert: counter equals: 1
+]
+
+{ #category : 'tests' }
+WeakAnnouncerTest >> testWeakSubscription [
+
+	| obj subscription |
+	obj := Object new.
+	subscription := (announcer when: AnnouncementMockA send: #value to: obj) makeWeak.
+	self assert: obj identicalTo: subscription subscriber
+]

--- a/src/Announcements-Core-GemStone/AnnouncementSubscription.class.st
+++ b/src/Announcements-Core-GemStone/AnnouncementSubscription.class.st
@@ -70,6 +70,29 @@ AnnouncementSubscription >> handlesAnnouncement: anAnnouncement [
 	^ announcementClass handlesAnnouncement: anAnnouncement
 ]
 
+{ #category : 'converting' }
+AnnouncementSubscription >> makeStrong [
+	"This subscription is already strong."
+
+	^self
+]
+
+{ #category : 'converting' }
+AnnouncementSubscription >> makeWeak [
+	"Convert to a WeakAnnouncementSubscription."
+
+	| newSub |
+	(action isKindOf: BlockClosure) ifTrue: [WeakBlockUnsupported signal].
+	newSub := WeakAnnouncementSubscription
+		announcer: announcer
+		announcementClass: announcementClass
+		receiver: action receiver
+		selector: action selector.
+	^announcer
+		replace: self
+		with: newSub
+]
+
 { #category : 'accessing' }
 AnnouncementSubscription >> subscriber [
 	^ subscriber

--- a/src/Announcements-Core-GemStone/Announcer.class.st
+++ b/src/Announcements-Core-GemStone/Announcer.class.st
@@ -146,6 +146,13 @@ Announcer >> unsubscribe: anObject [
 	registry removeSubscriber: anObject
 ]
 
+{ #category : 'accessing' }
+Announcer >> weak [
+	"Return an object which allows the creation of weak subscriptions"
+
+	^WeakSubscriptionBuilder on: self
+]
+
 { #category : 'registration api' }
 Announcer >> when: anAnnouncementClass do: aValuable [
 	"Declare that when anAnnouncementClass is raised, aValuable is executed.  Pay attention that such method as well as #when:do: should not be used on weak announcer since the block holds the receiver and more strongly."

--- a/src/Announcements-Core-GemStone/WeakAnnouncementSubscription.class.st
+++ b/src/Announcements-Core-GemStone/WeakAnnouncementSubscription.class.st
@@ -1,0 +1,136 @@
+"
+The subscription is a single entry in a SubscriptionRegistry.
+Several subscriptions by the same object is possible.
+
+This subscription references the receiver weakly. If the receiver is garbage collected, the subscription is automatically removed from the SubscriptionRegistry. A MessageSend is dynamically generated to make ephemeron finalization easier.
+"
+Class {
+	#name : 'WeakAnnouncementSubscription',
+	#superclass : 'Object',
+	#instVars : [
+		'receiver',
+		'selector',
+		'announcer',
+		'announcementClass',
+		'subscriber'
+	],
+	#category : 'Announcements-Core-GemStone'
+}
+
+{ #category : 'instance creation' }
+WeakAnnouncementSubscription class >> announcer: anAnnouncer
+announcementClass: anAnnouncementClass
+receiver: anObject
+selector: aSelector [
+
+	^self new
+		receiver: anObject;
+		selector: aSelector;
+		announcer: anAnnouncer;
+		announcementClass: anAnnouncementClass;
+		beEphemeron: true;
+		yourself
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> action [
+
+	^MessageSend
+		receiver: receiver
+		selector: selector
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> announcementClass [
+
+	^announcementClass
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> announcementClass: anAnnouncementClass [
+
+	announcementClass := anAnnouncementClass
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> announcer [
+
+	^announcer
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> announcer: anAnnouncer [
+
+	announcer := anAnnouncer
+]
+
+{ #category : 'announcing' }
+WeakAnnouncementSubscription >> deliver: anAnnouncement [
+
+	^ (self handlesAnnouncement: anAnnouncement ) ifTrue: [
+		[self action cull: anAnnouncement cull: announcer] 
+"Pharo has:
+			on: UnhandledError fork: [:ex | ex pass ]]
+GemStone has:
+"			on: Error
+			do: announcer deliveryErrorHandler]
+]
+
+{ #category : 'testing' }
+WeakAnnouncementSubscription >> handlesAnnouncement: anAnnouncement [
+
+	^ announcementClass handlesAnnouncement: anAnnouncement
+]
+
+{ #category : 'converting' }
+WeakAnnouncementSubscription >> makeStrong [
+
+	| newSub |
+	newSub := AnnouncementSubscription new
+		announcer: announcer;
+		announcementClass: announcementClass;
+		valuable: self action;
+		subscriber: receiver;
+		yourself.
+	self beEphemeron: false.
+	^announcer
+		replace: self
+		with: newSub
+]
+
+{ #category : 'converting' }
+WeakAnnouncementSubscription >> makeWeak [
+	"This subscription is already weak."
+
+	^self
+]
+
+{ #category : 'finalizing' }
+WeakAnnouncementSubscription >> mourn [
+
+	announcer removeSubscription: self
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> receiver: anObject [
+
+	receiver := anObject
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> selector: aSelector [
+
+	selector := aSelector
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> subscriber [
+
+	^receiver
+]
+
+{ #category : 'accessing' }
+WeakAnnouncementSubscription >> subscriber: anObject [
+
+	receiver := anObject
+]

--- a/src/Announcements-Core-GemStone/WeakBlockUnsupported.class.st
+++ b/src/Announcements-Core-GemStone/WeakBlockUnsupported.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : 'WeakBlockUnsupported',
+	#superclass : 'Error',
+	#category : 'Announcements-Core-GemStone'
+}

--- a/src/Announcements-Core-GemStone/WeakSubscriptionBuilder.class.st
+++ b/src/Announcements-Core-GemStone/WeakSubscriptionBuilder.class.st
@@ -1,0 +1,45 @@
+Class {
+	#name : 'WeakSubscriptionBuilder',
+	#superclass : 'Object',
+	#instVars : [
+		'announcer'
+	],
+	#category : 'Announcements-Core-GemStone'
+}
+
+{ #category : 'instance creation' }
+WeakSubscriptionBuilder class >> on: anAnnouncer [
+
+	^super new
+		announcer: anAnnouncer;
+		yourself
+]
+
+{ #category : 'accessing' }
+WeakSubscriptionBuilder >> announcer: anAnnouncer [
+
+	announcer := anAnnouncer
+]
+
+{ #category : 'accessing' }
+WeakSubscriptionBuilder >> weak [
+	"This already handles the creation of weak registrations."
+
+	^self
+]
+
+{ #category : 'registration' }
+WeakSubscriptionBuilder >> when: anAnnouncementClass
+send: aSelector
+to: anObject [
+
+	| subscription |
+	(anObject isKindOf: BlockClosure)
+		ifTrue: [WeakBlockUnsupported signal].
+	subscription := WeakAnnouncementSubscription
+		announcer: announcer
+		announcementClass: anAnnouncementClass
+		receiver: anObject
+		selector: aSelector.
+	^announcer basicSubscribe: subscription
+]


### PR DESCRIPTION
Special notes:
1. Only #when:send:to: is supported for Weak Announcement registration
2. Weak BlockClosure instances are not supported and will result in a raised WeakBlockUnsupported Error